### PR TITLE
Add handling of half-calls + plink refactoring

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -190,7 +190,8 @@ if (params.agg_vcf_file || params.individual_vcf_file){
         sed -i '/^GL/ d' $vcf
         plink --keep-allele-order \
         --vcf $vcf \
-        --make-bed
+        --make-bed \
+        --vcf-half-call m
         rm plink.fam
         mv $fam plink.fam
         """

--- a/main.nf
+++ b/main.nf
@@ -93,7 +93,7 @@ if (params.agg_vcf_file){
         file(pheno_file) from ch_pheno3
  
         output:
-        file 'filtered.vcf' into vcf_plink, vcf_to_annotate_ch
+        file 'filtered.vcf' into vcf_plink
 
         script:
         """
@@ -116,21 +116,6 @@ if (params.agg_vcf_file){
         sed '1d' $pheno_file | awk -F' ' '{print \$1}' > sample_file.txt
         bcftools view -S sample_file.txt merged.vcf > filtered.vcf
         """
-    }
-    if (params.cpra_annotate) {
-        process cpra_annotate {
-            container 'lifebitai/preprocess_gwas:latest'
-
-            input:
-            file(vcf) from vcf_to_annotate_ch
-            output:
-            file("annotated.vcf.gz") into annotated_vcf_ch
-
-            script:
-            """
-            bcftools annotate --set-id +'%CHROM-%POS-%REF-%FIRST_ALT' $vcf -Oz -o annotated.vcf.gz
-            """
-        }
     }
 }
 
@@ -185,7 +170,7 @@ if (params.individual_vcf_file) {
 
 }
 
-if (params.agg_vcf_file || params.individual_vcf_file) {
+if (params.agg_vcf_file || params.individual_vcf_file){
     process vcf_2_plink {
         tag "plink"
         publishDir "${params.outdir}/plink", mode: 'copy'

--- a/nextflow.config
+++ b/nextflow.config
@@ -1,6 +1,6 @@
 docker.enabled = true
 prepImage = 'lifebitai/preprocess_gwas:latest'
-plinkImage = 'alliecreason/plink:1.90'
+plinkImage = 'lifebitai/plink1:1.90b6.17'
 
 params {
     container='quay.io/lifebitai/phewas:latest'


### PR DESCRIPTION
# This PR does the following:

- Adds handling of half-calls (half-calls are set to missing) in vcf->plink conversion
- Adds refactoring around plink container and plink1.9 calls

# Details

- Adds handling of half-calls (half-calls are set to missing) in vcf->plink conversion. This step is necessary for GEL aggV2 data and should have no effect on other VCF data without half-calls.
- Some refactoring around specifying plink container  + switching to lifebit-ai plink1.9 container
- Addition of `plink --keep-allele-order` to every plink1.9 call. This is recommended for all plink1.9 calls as plink1.9 can swap ref and alt alleles if this option is not specified, which is dangerous.

# Test 

Local run on EC2 instance:

<img width="853" alt="Screenshot 2021-07-30 at 09 17 39" src="https://user-images.githubusercontent.com/33654687/127626083-c45bc35e-9003-408d-95ab-99270c9d2cf7.png">

GEL prod run:

<img width="1346" alt="Screenshot 2021-07-30 at 09 37 28" src="https://user-images.githubusercontent.com/33654687/127626181-c31e8522-7ef5-49e3-be78-20a934eeba28.png">
